### PR TITLE
Fix compile error in mod.nickserv

### DIFF
--- a/mod.nickserv/nickserv.h
+++ b/mod.nickserv/nickserv.h
@@ -147,7 +147,7 @@ class nickserv : public xClient, public logging::logTarget {
      *******************************/
 
     /** Holds a reference to our Stats collector */
-    Stats::Stats* theStats;
+    gnuworld::Stats* theStats;
 
     /** Holds a reference to our Logger instance */
     logging::Logger* theLogger;


### PR DESCRIPTION
`Stats::Stats` references the constructor, not a type. Use `gnuworld::Stats`.