### PR TITLE
Attempt to move server_command_map to $(pkgdatadir).

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,8 @@ SUBDIRS = libltdl $(NEW_MODS)
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES =
 
+pkgdata_DATA = bin/server_command_map
+
 EXTRA_DIST = bin/ccontrol.example.conf \
 	bin/chanfix.example.conf \
 	bin/clientExample.example.conf \
@@ -19,7 +21,6 @@ EXTRA_DIST = bin/ccontrol.example.conf \
 	bin/openchanfix.example.conf \
 	bin/scanner.example.conf \
 	bin/stats.example.conf \
-	bin/server_command_map \
 	contrib/00INDEX.TXT \
 	contrib/chktrans.py \
 	contrib/encrypt.sh \

--- a/bin/GNUWorld.example.conf
+++ b/bin/GNUWorld.example.conf
@@ -29,7 +29,7 @@ hidden_host_suffix = .users.undernet.org
 # from module filenames (of server command handlers) to the
 # message name to which it is associated.
 # You probably will not need to ever change this.
-command_map = server_command_map
+command_map = ../share/gnuworld/server_command_map
 
 # libdir is the path to the directory containing
 # the gnuworld modules


### PR DESCRIPTION
I have not tested this, but with such a short change, what could go wrong?!

This should work fine after "make install" but the command map will not be in the right place after just checking out the repository and compiling it.  The "gnuworld-ish" solution was not obvious to me.