### PR TITLE
Enhancements to configuration parser

### DIFF
--- a/libgnuworld/EConfig.cc
+++ b/libgnuworld/EConfig.cc
@@ -459,6 +459,8 @@ return writeFile() ;
 
 void EConfig::Clear()
 {
+	error = false;
+	configErrors.clear();
 	valueMap.clear();
 }
 


### PR DESCRIPTION
- Added new Require() function to return configuration variables of a given type. Provides explanatory message if config option is of wrong type.
- Added new TryRequire() function intended to be called upon a runtime rehash. Returns variable of given type. If the value is incorrect, the original value (provided as an argument) is returned and error is logged but no exit. 