### PR TITLE
Add missing sstream include for ostringstream in EConfig.h and logger.h

### DIFF
--- a/libgnuworld/EConfig.h
+++ b/libgnuworld/EConfig.h
@@ -29,6 +29,7 @@
 #include	<list>
 #include	<map>
 #include	<concepts>
+#include	<sstream>
 
 #include	"ELog.h"
 #include	"misc.h" // noCaseCompare

--- a/libgnuworld/logger.h
+++ b/libgnuworld/logger.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <fstream>
+#include <sstream>
 #include <functional>
 #include <typeindex>
 #ifdef HAVE_FORMAT


### PR DESCRIPTION
Added missing `#include <sstream>` to fix compilation issues with modern C++ compilers.
Successfully compiled on Ubuntu 22.04 with g++ 11.4.0